### PR TITLE
closes #22

### DIFF
--- a/ReefAngel/ReefAngel.cpp
+++ b/ReefAngel/ReefAngel.cpp
@@ -262,8 +262,14 @@ const prog_char setupmenu_4_label[] PROGMEM = "Calibrate Sal";
 #ifdef ORPEXPANSION
 const prog_char setupmenu_5_label[] PROGMEM = "Calibrate ORP";
 #endif  // ORPEXPANSION
+#ifdef PHEXPANSION
+const prog_char setupmenu_6_label[] PROGMEM = "Calibrate PH Exp";
+#endif  // PHEXPANSION
+#ifdef WATERLEVELEXPANSION
+const prog_char setupmenu_7_label[] PROGMEM = "Calibrate Water";
+#endif  // WATERLEVELEXPANSION
 #ifdef DateTimeSetup
-const prog_char setupmenu_6_label[] PROGMEM = "Date / Time";
+const prog_char setupmenu_8_label[] PROGMEM = "Date / Time";
 #endif  // DateTimeSetup
 PROGMEM const char *setupmenu_items[] = {
 #ifdef WavemakerSetup
@@ -282,8 +288,14 @@ PROGMEM const char *setupmenu_items[] = {
 #ifdef ORPEXPANSION
                     setupmenu_5_label,
 #endif  // ORPEXPANSION
+#ifdef PHEXPANSION
+					setupmenu_6_label,
+#endif  // PHEXPANSION
+#ifdef WATERLEVELEXPANSION
+					setupmenu_7_label,
+#endif  // WATERLEVELEXPANSION
 #ifdef DateTimeSetup
-                    setupmenu_6_label
+                    setupmenu_8_label
 #endif  // DateTimeSetup
                     };
 enum SetupMenuItem {
@@ -303,6 +315,12 @@ enum SetupMenuItem {
 #ifdef ORPEXPANSION
     SetupMenu_CalibrateORP,
 #endif  // ORPEXPANSION
+#ifdef PHEXPANSION
+	SetupMenu_PHExpCalibration,
+#endif  // PHEXPANSION
+#ifdef WATERLEVELEXPANSION
+	SetupMenu_WaterCalibration,
+#endif  // WATERLEVELEXPANSION
 #ifdef DateTimeSetup
     SetupMenu_DateTime
 #endif  // DateTimeSetup
@@ -2475,6 +2493,20 @@ void ReefAngelClass::ProcessButtonPressSetup()
             break;
         }
 #endif  // ORPEXPANSION
+#ifdef PHEXPANSION
+		case SetupMenu_PHExpCalibration:
+		{
+			SetupCalibratePHExp();
+			break;
+		}
+#endif  // PHEXPANSION
+#ifdef WATERLEVELEXPANSION
+		case SetupMenu_WaterCalibration:
+		{
+			SetupCalibrateWaterLevel();
+			break;
+		}
+#endif  // WATERLEVELEXPANSION
 #ifdef DateTimeSetup
         case SetupMenu_DateTime:
         {


### PR DESCRIPTION
Calibration menu added for the simple and standard menus.  The only problem would be with all expansion modules enabled on the simple menu.  This would not display the last 2 entries on the menu (date / time setup and version menu and exit ) because the maximum entries allowed is 9.  This shouldn't be a problem currently because when all of those features are enabled, you will not be able to compile the code for the normal controller unless wifi is removed (haven't tested this).  So I will need to improve the menu displaying to allow for more than 9 entries.  Not critical right now, but can be in the future.
