### PR TITLE
Fixed MoonPhaseLabel bug, fixes #33

### DIFF
--- a/Globals/Globals.cpp
+++ b/Globals/Globals.cpp
@@ -131,7 +131,7 @@ void ConvertNumToString(char* string, int num, byte decimal)
 	}
 }
 
-#ifdef MoonPhaseLabel
+#ifdef MOONPHASELABEL
 char* MoonPhaseLabel()
 {
   int m,d,y;
@@ -162,7 +162,7 @@ char* MoonPhaseLabel()
   else if (V<0.9375) return "Waning Crescent";
   else return "New Moon";
 }
-#endif // MoonPhaseLabel
+#endif // MOONPHASELABEL
 
 int alphaBlend(int fgcolor, byte a)
 {

--- a/Globals/Globals.h
+++ b/Globals/Globals.h
@@ -894,9 +894,9 @@ byte PWMParabola(byte startHour, byte startMinute, byte endHour, byte endMinute,
 byte MoonPhase();
 void ConvertNumToString(char* string, int num, byte decimal);
 inline double LinearInterpolation(double x, double x1, double y1, double x2, double y2) { return y1 + (y2 - y1) / (x2 - x1) * (x - x1); }
-#ifdef MoonPhaseLabel
+#ifdef MOONPHASELABEL
 char* MoonPhaseLabel();
-#endif // MoonPhaseLabel
+#endif // MOONPHASELABEL
 
 // 16bit color alpha blend
 int alphaBlend(int fgcolor, byte a);


### PR DESCRIPTION
The problem was with a function declaration and a define statement using the same word.  The function was MoonPhaseLabel and the define statement was MoonPhaseLabel.  The compiler was getting confused with what to use.
