### PR TITLE
Fix for issue #24. Added option to use 12h or 24h clock.

### DIFF
--- a/Globals/Globals.cpp
+++ b/Globals/Globals.cpp
@@ -131,6 +131,39 @@ void ConvertNumToString(char* string, int num, byte decimal)
 	}
 }
 
+#ifdef MOONPHASELABEL
+char* MoonPhaseLabel()
+{
+  int m,d,y;
+  int yy,mm;
+  long K1,K2,K3,J;
+  double V;
+  byte PWMvalue;
+  m = month();
+  d = day();
+  y = year();
+  yy = y-((12-m)/10);
+  mm = m+9;
+  if (mm>=12) mm -= 12;
+  K1 = 365.25*(yy+4712);
+  K2 = 30.6*mm+.5;
+  K3 = int(int((yy/100)+49)*.75)-38;
+  J = K1+K2+d+59-K3;
+  V = (J-2451550.1)/29.530588853;
+  V -= floor(V);
+  if (V<0) V++;
+  if (V<0.0625) return "New Moon";
+  else if (V<0.1875) return "Waxing Crescent";
+  else if (V<0.3125) return "First Quarter";
+  else if (V<0.4375) return "Waxing Gibbous";
+  else if (V<0.5625) return "Fuul Moon";
+  else if (V<0.6875) return "Waning Gibbous";
+  else if (V<0.8125) return "Last Quarter";
+  else if (V<0.9375) return "Waning Crescent";
+  else return "New Moon";
+}
+#endif // MOONPHASELABEL
+
 int alphaBlend(int fgcolor, byte a)
 {
 	int r=((fgcolor>>11)&0x1f)<<3;

--- a/Globals/Globals.h
+++ b/Globals/Globals.h
@@ -32,6 +32,11 @@
 
 #include <avr/pgmspace.h>
 
+#if defined(__AVR_ATmega2560__)
+#define wifi
+#define DateTimeSetup
+#endif //__AVR_ATmega2560__
+
 const prog_char NoIMCheck[] PROGMEM = "No Internal Memory";
 const prog_char NoIMCheck1[] PROGMEM = "Found";
 
@@ -346,9 +351,10 @@ When adding more variables, use the previous value plus 1 or 2
 #define Mem_I_PHExpMax			  VarsStart+123
 #define Mem_I_WaterLevelMin			  VarsStart+125
 #define Mem_I_WaterLevelMax			  VarsStart+127
+#define Mem_B_TimeUse12Hours       	  VarsStart+129
 
-#define VarsEnd                 VarsStart+129
-// Next value starts VarsStart+129
+#define VarsEnd                 VarsStart+130
+// Next value starts VarsStart+130
 
 
 // EEProm Pointers
@@ -888,6 +894,10 @@ byte PWMSlope(byte startHour, byte startMinute, byte endHour, byte endMinute, by
 byte PWMParabola(byte startHour, byte startMinute, byte endHour, byte endMinute, byte startPWM, byte endPWM, byte oldValue);
 byte MoonPhase();
 void ConvertNumToString(char* string, int num, byte decimal);
+inline double LinearInterpolation(double x, double x1, double y1, double x2, double y2) { return y1 + (y2 - y1) / (x2 - x1) * (x - x1); }
+#ifdef MOONPHASELABEL
+char* MoonPhaseLabel();
+#endif // MOONPHASELABEL
 
 // 16bit color alpha blend
 int alphaBlend(int fgcolor, byte a);

--- a/InternalEEPROM/InternalEEPROM.cpp
+++ b/InternalEEPROM/InternalEEPROM.cpp
@@ -798,6 +798,18 @@ void InternalEEPROMClass::DelayedStart_write(const uint8_t value)
     write(Mem_B_DelayedStart, value);
 }
 
+uint8_t InternalEEPROMClass::TimeUse12Hour_read()
+{
+    return read(Mem_B_TimeUse12Hours);
+}
+
+void InternalEEPROMClass::TimeUse12Hour_write(uint8_t value)
+{
+	value = constrain(value, 0, 1);
+	
+    write(Mem_B_TimeUse12Hours, value);
+}
+
 // Int Functions
 int InternalEEPROMClass::WM1Timer_read()
 {
@@ -1068,6 +1080,7 @@ void InternalEEPROMClass::IMCheck_write(const unsigned long value)
 {
 	write_dword(IMPointer, value);
 }
+
 
 // Private functions
 uint8_t InternalEEPROMClass::read(int address)

--- a/InternalEEPROM/InternalEEPROM.h
+++ b/InternalEEPROM/InternalEEPROM.h
@@ -183,6 +183,8 @@ class InternalEEPROMClass {
         void RadionSlopeDurationI_write(const uint8_t value);        
         uint8_t DelayedStart_read();
         void DelayedStart_write(const uint8_t value);        
+		uint8_t TimeUse12Hour_read();
+		void TimeUse12Hour_write(uint8_t value);
         
         // Functions that read/write an int
         int WM1Timer_read();

--- a/RA_NokiaLCD/RA_NokiaLCD.cpp
+++ b/RA_NokiaLCD/RA_NokiaLCD.cpp
@@ -1208,6 +1208,50 @@ void RA_NokiaLCD::DrawDate(byte x, byte y)
     DrawText(DateTextColor, DefaultBGColor, x, y, text);
 }
 
+#if defined(__AVR_ATmega2560__)
+// Draw date and time according to ISO 8601
+// Example: 2012-05-25 21:48:43
+void RA_NokiaLCD::DrawDateTimeISO8601(byte x, byte y)
+{
+    char text[20];
+    char temp2[]="  ";
+    char temp4[]="    ";
+    strcpy(text,"");
+	
+	// Date
+	itoa(year(),temp4,10);
+    strcat(text,temp4);
+    strcat(text,"-");
+	
+    itoa(month(),temp2,10);
+    if (temp2[1]==0) strcat(text,"0");
+    strcat(text,temp2);
+    strcat(text,"-");
+	
+    itoa(day(),temp2,10);
+    if (temp2[1]==0) strcat(text,"0");
+    strcat(text,temp2);
+    strcat(text," ");
+	
+	// Time
+    itoa(hour(),temp2,10);
+    if (temp2[1]==0) strcat(text,"0");
+    strcat(text,temp2);
+    strcat(text,":");
+	
+    itoa(minute(),temp2,10);
+    if (temp2[1]==0) strcat(text,"0");
+    strcat(text,temp2);
+    strcat(text,":");
+	
+    itoa(second(),temp2,10);
+    if (temp2[1]==0) strcat(text,"0");
+    strcat(text,temp2);
+    
+    DrawText(DateTextColor, DefaultBGColor, x, y, text);
+}
+#endif // __AVR_ATmega2560__
+
 void RA_NokiaLCD::DrawOutletBox(byte x, byte y,byte RelayData)
 {
     Clear(OutletBorderColor,x,y,x+104,y);  //94
@@ -1434,8 +1478,9 @@ void RA_NokiaLCD::DrawOK(bool Selected)
 
 void RA_NokiaLCD::DrawCalibrate(int i, byte x, byte y)
 {
-  char text[5] = {0};
+  char text[10] = {0};
   Clear(DefaultBGColor, x, y, x+20, y+10);
   itoa(i,text,10);
+  strcat(text , "   ");
   DrawText(CalibrateColor, DefaultBGColor, x, y, text);
 }

--- a/RA_NokiaLCD/RA_NokiaLCD.h
+++ b/RA_NokiaLCD/RA_NokiaLCD.h
@@ -64,6 +64,9 @@ public:
 	void FillCircle(byte x, byte y, byte radius, byte fillcolor);
 	void DrawCircleOutletBox(byte x, byte y, byte RelayData, bool reverse = false);
 	void DrawDate(byte x, byte y);
+	#if defined(__AVR_ATmega2560__)
+	void DrawDateTimeISO8601(byte x, byte y);
+	#endif
 	void DrawOutletBox(byte x, byte y, byte RelayData);
 #if defined DisplayLEDPWM && ! defined RemoveAllLights
 	void DrawMonitor(byte x, byte y, ParamsStruct Params, byte DaylightPWMValue, byte ActinicPWMValue);

--- a/RA_Wifi/RA_Wifi.cpp
+++ b/RA_Wifi/RA_Wifi.cpp
@@ -380,15 +380,22 @@ void processHTTP()
 			{
 				int s;
 
+				// if memory location is > 800 it means app is trying to pull/set old memory location.
+				// we decrease 600 to start using new memory map
+				// this is a temporary solution until we get all apps to point to new memory location
+				int newweboption2=weboption2;
+				if ( weboption2>=800 ) newweboption2-=600;
+
 				// weboption2 is location
 				// weboption is value
 				if ( bHasSecondValue && (weboption2 >= 0) )
 				{
+					
 					// if we have a second value, we write the value to memory
 					if ( reqtype == REQ_M_BYTE )
-						InternalMemory.write(weboption2, weboption);
+						InternalMemory.write(newweboption2, weboption);
 					else
-						InternalMemory.write_int(weboption2, weboption);
+						InternalMemory.write_int(newweboption2, weboption);
 
 					// check if we have to reload any timers
 					if ( weboption2 == Mem_I_FeedingTimer )
@@ -413,7 +420,7 @@ void processHTTP()
 //						ReefAngel.Timer[PORTAL_TIMER].ForceTrigger();
 //					}
 //#endif  // DisplayLEDPWM
-
+					
 					s = 9;  // <M>OK</M>
 					// add in the location, twice
 					s += (intlength(weboption2)*2);
@@ -435,9 +442,9 @@ void processHTTP()
 					s += (intlength(weboption2)*2);
 					// length of the value from memory
 					if ( reqtype == REQ_M_BYTE )
-						s += intlength(InternalMemory.read(weboption2));
+						s += intlength(InternalMemory.read(newweboption2));
 					else
-						s += intlength(InternalMemory.read_int(weboption2));
+						s += intlength(InternalMemory.read_int(newweboption2));
 
 					PrintHeader(s,1);
 
@@ -446,9 +453,9 @@ void processHTTP()
 					WIFI_SERIAL.print(weboption2, DEC);
 					PROGMEMprint(XML_CLOSE_TAG);
 					if ( reqtype == REQ_M_BYTE )
-						WIFI_SERIAL.print(InternalMemory.read(weboption2),DEC);
+						WIFI_SERIAL.print(InternalMemory.read(newweboption2),DEC);
 					else
-						WIFI_SERIAL.print(InternalMemory.read_int(weboption2),DEC);
+						WIFI_SERIAL.print(InternalMemory.read_int(newweboption2),DEC);
 					PROGMEMprint(XML_M_CLOSE);
 					WIFI_SERIAL.print(weboption2, DEC);
 					PROGMEMprint(XML_CLOSE_TAG);
@@ -475,7 +482,7 @@ void processHTTP()
 				for ( int x = VarsStart; x < VarsEnd; x++ )
 				{
 					m=InternalMemory.read(x);
-					if (m<17) WIFI_SERIAL.print("0");
+					if (m<16) WIFI_SERIAL.print("0");
 					WIFI_SERIAL.print(m,HEX);
 				}  // for x
 				PROGMEMprint(XML_MEM_CLOSE);
@@ -528,14 +535,14 @@ void processHTTP()
 				for ( x = 0, count = VarsStart; x < num; x++ )
 				{
 					PROGMEMprint(XML_M_OPEN);
-					WIFI_SERIAL.print(count,DEC);
+					WIFI_SERIAL.print(count+600,DEC); // 600 was added as temp fix - issue #26
 					PROGMEMprint(XML_CLOSE_TAG);
 					if ( offsets[x] == 1 )
 						WIFI_SERIAL.print(InternalMemory.read(count),DEC);
 					else
 						WIFI_SERIAL.print(InternalMemory.read_int(count),DEC);
 					PROGMEMprint(XML_M_CLOSE);
-					WIFI_SERIAL.print(count,DEC);
+					WIFI_SERIAL.print(count+600,DEC); // 600 was added as temp fix - issue #26
 					PROGMEMprint(XML_CLOSE_TAG);
 					count += offsets[x];
 				}  // for x

--- a/ReefAngel/ReefAngel.cpp
+++ b/ReefAngel/ReefAngel.cpp
@@ -133,11 +133,17 @@ const prog_char mainmenu_5_label[] PROGMEM = "Sal Calibration";
 #ifdef ORPEXPANSION
 const prog_char mainmenu_6_label[] PROGMEM = "ORP Calibration";
 #endif  // ORPEXPANSION
+#ifdef PHEXPANSION
+const prog_char mainmenu_7_label[] PROGMEM = "PH Exp Calibration";
+#endif  // PHEXPANSION
+#ifdef WATERLEVELEXPANSION
+const prog_char mainmenu_8_label[] PROGMEM = "Water Calibration";
+#endif  // WATERLEVELEXPANSION
 #ifdef DateTimeSetup
-const prog_char mainmenu_7_label[] PROGMEM = "Date / Time";
+const prog_char mainmenu_9_label[] PROGMEM = "Date / Time";
 #endif  // DateTimeSetup
 #ifdef VersionMenu
-const prog_char mainmenu_8_label[] PROGMEM = "Version";
+const prog_char mainmenu_10_label[] PROGMEM = "Version";
 #endif  // VersionMenu
 PROGMEM const char *mainmenu_items[] = {
                     mainmenu_0_label,
@@ -151,11 +157,17 @@ PROGMEM const char *mainmenu_items[] = {
 #ifdef ORPEXPANSION
                     mainmenu_6_label,
 #endif  // ORPEXPANSION
+#ifdef PHEXPANSION
+					mainmenu_7_label,
+#endif  // PHEXPANSION
+#ifdef WATERLEVELEXPANSION
+					mainmenu_8_label,
+#endif  // WATERLEVELEXPANSION
 #ifdef DateTimeSetup
-                    mainmenu_7_label,
+                    mainmenu_9_label,
 #endif  // DateTimeSetup
 #ifdef VersionMenu
-                    mainmenu_8_label
+                    mainmenu_10_label
 #endif  // VersionMenu
                     };
 enum MainMenuItem {
@@ -170,6 +182,12 @@ enum MainMenuItem {
 #ifdef ORPEXPANSION
     MainMenu_ORPCalibration,
 #endif  // ORPEXPANSION
+#ifdef PHEXPANSION
+	MainMenu_PHExpCalibration,
+#endif  // PHEXPANSION
+#ifdef WATERLEVELEXPANSION
+	MainMenu_WaterCalibration,
+#endif  // WATERLEVELEXPANSION
 #ifdef DateTimeSetup
     MainMenu_DateTime,
 #endif  // DateTimeSetup
@@ -244,8 +262,14 @@ const prog_char setupmenu_4_label[] PROGMEM = "Calibrate Sal";
 #ifdef ORPEXPANSION
 const prog_char setupmenu_5_label[] PROGMEM = "Calibrate ORP";
 #endif  // ORPEXPANSION
+#ifdef PHEXPANSION
+const prog_char setupmenu_6_label[] PROGMEM = "Calibrate PH Exp";
+#endif  // PHEXPANSION
+#ifdef WATERLEVELEXPANSION
+const prog_char setupmenu_7_label[] PROGMEM = "Calibrate Water";
+#endif  // WATERLEVELEXPANSION
 #ifdef DateTimeSetup
-const prog_char setupmenu_6_label[] PROGMEM = "Date / Time";
+const prog_char setupmenu_8_label[] PROGMEM = "Date / Time";
 #endif  // DateTimeSetup
 PROGMEM const char *setupmenu_items[] = {
 #ifdef WavemakerSetup
@@ -264,8 +288,14 @@ PROGMEM const char *setupmenu_items[] = {
 #ifdef ORPEXPANSION
                     setupmenu_5_label,
 #endif  // ORPEXPANSION
+#ifdef PHEXPANSION
+					setupmenu_6_label,
+#endif  // PHEXPANSION
+#ifdef WATERLEVELEXPANSION
+					setupmenu_7_label,
+#endif  // WATERLEVELEXPANSION
 #ifdef DateTimeSetup
-                    setupmenu_6_label
+                    setupmenu_8_label
 #endif  // DateTimeSetup
                     };
 enum SetupMenuItem {
@@ -285,6 +315,12 @@ enum SetupMenuItem {
 #ifdef ORPEXPANSION
     SetupMenu_CalibrateORP,
 #endif  // ORPEXPANSION
+#ifdef PHEXPANSION
+	SetupMenu_PHExpCalibration,
+#endif  // PHEXPANSION
+#ifdef WATERLEVELEXPANSION
+	SetupMenu_WaterCalibration,
+#endif  // WATERLEVELEXPANSION
 #ifdef DateTimeSetup
     SetupMenu_DateTime
 #endif  // DateTimeSetup
@@ -433,10 +469,10 @@ void ReefAngelClass::Init()
 	Relay.AllOff();
 	OverheatProbe = T2_PROBE;
 	TempProbe = T1_PROBE;
-	
+
 	//0x5241494D
 	//0xCF06A31E
-	if (InternalMemory.IMCheck_read()!=0xCF06A31E) 
+	if (InternalMemory.IMCheck_read()!=0xCF06A31E)
 	{
 		char temptext[25];
 		while(1)
@@ -662,7 +698,7 @@ void ReefAngelClass::Refresh()
 	Params.PHExp=PH.Read();
 	if (Params.PHExp!=0)
 	{
-		Params.PHExp=map(Params.PH, PHExpMin, PHExpMax, 700, 1000); // apply the calibration to the sensor reading
+		Params.PHExp=map(Params.PHExp, PHExpMin, PHExpMax, 700, 1000); // apply the calibration to the sensor reading
 		Params.PHExp=constrain(Params.PHExp,100,1400);
 	}
 	LCD.Clear(DefaultBGColor,0,0,1,1);
@@ -695,12 +731,22 @@ void ReefAngelClass::Refresh()
 	Params.PH=constrain(Params.PH,100,1400);
 
 #if defined SALINITYEXPANSION
-	Params.Salinity=Salinity.Read();
+	unsigned long tempsal=0;
+    for (int a=0;a<20;a++)
+    {
+    	tempsal+=Salinity.Read();
+    }
+	Params.Salinity=tempsal/20;
 	Params.Salinity=map(Params.Salinity, 0, SalMax, 60, 350); // apply the calibration to the sensor reading
 	LCD.PutPixel(DefaultBGColor,1,1);
 #endif  // defined SALINITYEXPANSION
 #if defined ORPEXPANSION
-	Params.ORP=ORP.Read();
+	unsigned long temporp=0;
+    for (int a=0;a<20;a++)
+    {
+    	temporp+=ORP.Read();
+    }
+	Params.ORP=temporp/20;
 	if (Params.ORP!=0)
 	{
 		Params.ORP=map(Params.ORP, ORPMin, ORPMax, 0, 470); // apply the calibration to the sensor reading
@@ -709,10 +755,15 @@ void ReefAngelClass::Refresh()
 	LCD.PutPixel(DefaultBGColor,1,1);
 #endif  // defined ORPEXPANSION
 #if defined PHEXPANSION
-	Params.PHExp=PH.Read();
+	unsigned long tempph=0;
+    for (int a=0;a<20;a++)
+    {
+    	tempph+=PH.Read();
+    }
+	Params.PHExp=tempph/20;
 	if (Params.PHExp!=0)
 	{
-		Params.PHExp=map(Params.PH, PHExpMin, PHExpMax, 700, 1000); // apply the calibration to the sensor reading
+		Params.PHExp=map(Params.PHExp, PHExpMin, PHExpMax, 700, 1000); // apply the calibration to the sensor reading
 		Params.PHExp=constrain(Params.PHExp,100,1400);
 	}
 	LCD.Clear(DefaultBGColor,0,0,1,1);
@@ -1184,14 +1235,14 @@ void ReefAngelClass::CO2Control(byte Relay)
 {
     CO2Control(Relay,
                 InternalMemory.CO2ControlOff_read(),
-                InternalMemory.CO2ControlOn_read());	
+                InternalMemory.CO2ControlOn_read());
 }
 
 void ReefAngelClass::PHControl(byte Relay)
 {
 	PHControl(Relay,
                 InternalMemory.PHControlOn_read(),
-                InternalMemory.PHControlOff_read());	
+                InternalMemory.PHControlOff_read());
 }
 
 void ReefAngelClass::StandardATO(byte Relay)
@@ -1475,7 +1526,7 @@ void ReefAngelClass::SendPortal(char *username, char*key)
 #ifdef PHEXPANSION
 	PROGMEMprint(BannerPHE);
 	WIFI_SERIAL.print(Params.PHExp, DEC);
-#endif  // PHEXPANSION	
+#endif  // PHEXPANSION
 #ifdef WATERLEVELEXPANSION
 	PROGMEMprint(BannerWL);
 	WIFI_SERIAL.print(WaterLevel.GetLevel(), DEC);
@@ -1694,7 +1745,16 @@ void ReefAngelClass::ShowInterface()
 #else
 				// display everything on the home screen except the graph
 				// the graph is drawn/updated when we exit the main menu & when the parameters are saved
+#if defined(__AVR_ATmega2560__)
+				if(InternalMemory.TimeUse12Hour_read())
+				{
+					LCD.DrawDate(6, 112);
+				} else {
+					LCD.DrawDateTimeISO8601(6, 112);
+				}
+#else
 				LCD.DrawDate(6, 112);
+#endif // __AVR_ATmega2560__
 #if defined DisplayLEDPWM && ! defined RemoveAllLights
 				LCD.DrawMonitor(15, 60, Params, PWM.GetDaylightValue(), PWM.GetActinicValue());
 #else  // defined DisplayLEDPWM && ! defined RemoveAllLights
@@ -2291,10 +2351,28 @@ void ReefAngelClass::ProcessButtonPressMain()
             break;
         }
 #endif  // ORPEXPANSION
-#ifdef DateTimeSetup
+#ifdef PHEXPANSION
+		case MainMenu_PHExpCalibration:
+		{
+			SetupCalibratePHExp();
+			break;
+		}
+#endif  // PHEXPANSION
+#ifdef WATERLEVELEXPANSION
+		case MainMenu_WaterCalibration:
+		{
+			SetupCalibrateWaterLevel();
+			break;
+		}
+#endif  // WATERLEVELEXPANSION
+#if defined DateTimeSetup || defined DATETIME24
 		case MainMenu_DateTime:
 		{
+#ifdef DATETIME24
+            SetupDateTime24();
+#else
 			SetupDateTime();
+#endif
 			break;
 		}
 #endif  // DateTimeSetup
@@ -2428,10 +2506,28 @@ void ReefAngelClass::ProcessButtonPressSetup()
             break;
         }
 #endif  // ORPEXPANSION
-#ifdef DateTimeSetup
+#ifdef PHEXPANSION
+		case SetupMenu_PHExpCalibration:
+		{
+			SetupCalibratePHExp();
+			break;
+		}
+#endif  // PHEXPANSION
+#ifdef WATERLEVELEXPANSION
+		case SetupMenu_WaterCalibration:
+		{
+			SetupCalibrateWaterLevel();
+			break;
+		}
+#endif  // WATERLEVELEXPANSION
+#if defined DateTimeSetup || defined DATETIME24
         case SetupMenu_DateTime:
         {
-            SetupDateTime();
+#ifdef DATETIME24
+            SetupDateTime24();
+#else
+			SetupDateTime();
+#endif
             break;
         }
 #endif  // DateTimeSetup
@@ -2923,19 +3019,23 @@ void ReefAngelClass::SetupLightsOptionDisplay(bool bMetalHalide)
     byte offset_min = offset_hr+20;
     if ( bMetalHalide )
     {
+#ifdef MetalHalideSetup
         strcpy(msg, "Metal Halide Setup");
         h1 = InternalMemory.MHOnHour_read();
         m1 = InternalMemory.MHOnMinute_read();
         h2 = InternalMemory.MHOffHour_read();
         m2 = InternalMemory.MHOffMinute_read();
+#endif // MetalHalideSetup
     }
     else
     {
+#ifdef StandardLightSetup
         strcpy(msg, "Std Lights Setup");
         h1 = InternalMemory.StdLightsOnHour_read();
         m1 = InternalMemory.StdLightsOnMinute_read();
         h2 = InternalMemory.StdLightsOffHour_read();
         m2 = InternalMemory.StdLightsOffMinute_read();
+#endif // StandardLightSetup
     }
     ClearScreen(DefaultBGColor);
     // header / title
@@ -3156,17 +3256,21 @@ void ReefAngelClass::SetupLightsOptionDisplay(bool bMetalHalide)
     {
         if ( bMetalHalide )
         {
+#ifdef MetalHalideSetup
             InternalMemory.MHOnHour_write(h1);
             InternalMemory.MHOnMinute_write(m1);
             InternalMemory.MHOffHour_write(h2);
             InternalMemory.MHOffMinute_write(m2);
+#endif MetalHalideSetup
         }
         else
         {
+#ifdef StandardLightSetup
             InternalMemory.StdLightsOnHour_write(h1);
             InternalMemory.StdLightsOnMinute_write(m1);
             InternalMemory.StdLightsOffHour_write(h2);
             InternalMemory.StdLightsOffMinute_write(m2);
+#endif // StandardLightSetup
         }
     }
 }
@@ -3247,6 +3351,226 @@ void ReefAngelClass::SetupCalibratePH()
 		PHMax = iO[1];
 	}
 }
+
+#ifdef SetupCalibrateChoicePH
+void ReefAngelClass::SetupCalibrateChoicePH()
+{
+	enum choices {
+        TARGETPH,
+        CANCEL,
+        OK
+    };
+    byte sel = CANCEL;
+	
+    bool bOKSel = false;
+    bool bSave = false;
+    bool bDone = false;
+    bool bRedraw = true;
+    bool bDrawButtons = true;
+    unsigned int iStart[2] = {7,10};
+    unsigned int iTarget[2] = {0,0};
+    unsigned int iValue[2] = {0,0};
+    char msg[15];
+	unsigned int maxPh = 10;
+	unsigned int minPh = 4;
+    byte offset = 65;
+		
+    // draw labels
+    ClearScreen(DefaultBGColor);
+    for (int b=0;b<2;b++)
+    {
+    	if (b==1 && !bSave) break;
+    	bOKSel=false;
+    	bSave=false;
+    	bDone = false;
+		bRedraw = true;
+    	bDrawButtons = true;
+		LCD.DrawText(DefaultFGColor, DefaultBGColor, MENU_START_COL, MENU_START_ROW, "Calibrate pH");		
+		LCD.DrawText(DefaultFGColor, DefaultBGColor, MENU_START_COL, MENU_START_ROW*6, "pH");
+		
+		strcpy(msg, b==0 ? "First value\0" : "Second value\0");
+		LCD.DrawText(DefaultFGColor, DefaultBGColor, MENU_START_COL, MENU_START_ROW*4, msg);
+		
+		iTarget[b] = iStart[b];
+		if(b==1 && iTarget[0]==iTarget[b])
+		{
+			iTarget[b]--;
+		}
+	
+		do
+		{
+#if defined WDT || defined WDT_FORCE
+			wdt_reset();
+#endif  // defined WDT || defined WDT_FORCE
+			iValue[b]=0;
+			for (int a=0;a<30;a++)
+			{
+				iValue[b] += analogRead(PHPin);
+			}
+			iValue[b]/=30;
+			LCD.DrawCalibrate(iValue[b], MENU_START_COL + offset, MENU_START_ROW*6);
+			
+			
+			if ( bRedraw )
+			{
+				switch ( sel )
+				{
+					case TARGETPH:
+					{
+						LCD.DrawOption(iTarget[b], 1, MENU_START_COL + 18, MENU_START_ROW*6, "", "", 2);
+						if ( bDrawButtons )
+						{
+							LCD.DrawOK(false);
+							LCD.DrawCancel(false);
+						}
+						break;
+					}
+					case OK:
+					{
+						if ( bDrawButtons )
+						{
+							LCD.DrawOption(iTarget[b], 0, MENU_START_COL + 18, MENU_START_ROW*6, "", "", 2);
+							LCD.DrawOK(true);
+							LCD.DrawCancel(false);
+						}
+						break;
+					}
+					case CANCEL:
+					{
+						if ( bDrawButtons )
+						{
+							LCD.DrawOption(iTarget[b], 0, MENU_START_COL + 18, MENU_START_ROW*6, "", "", 2);
+							LCD.DrawOK(false);
+							LCD.DrawCancel(true);
+						}
+						break;
+					}
+				}
+				bRedraw = false;
+				bDrawButtons = false;
+			}
+			
+			if ( Joystick.IsUp() )
+			{
+				if (sel == TARGETPH)
+				{
+					iTarget[b]++;
+					if(b==1 && iTarget[0]==iTarget[b])
+					{
+						if((iTarget[b] + 1) <= maxPh)
+						{
+							iTarget[b]++;
+						} else {
+							iTarget[b]--;
+						}
+					}
+					
+					if ( iTarget[b] > maxPh )
+					{
+						iTarget[b] = maxPh;
+					}
+					else 
+					{
+						bRedraw = true;
+					}
+				}
+			}
+			if ( Joystick.IsDown() )
+			{
+				if (sel == TARGETPH)
+				{
+					iTarget[b]--;
+					if(b==1 && iTarget[0]==iTarget[b])
+					{
+						if((iTarget[b] - 1) >= minPh)
+						{
+							iTarget[b]--;
+						} else {
+							iTarget[b]++;
+						}
+					}
+					
+					if ( iTarget[b] < minPh )
+					{
+						iTarget[b] = minPh;
+					}
+					else 
+					{
+						bRedraw = true;
+					}
+				}
+			}
+			
+			if ( Joystick.IsLeft() )
+			{
+				bRedraw = true;
+				bDrawButtons = true;
+				sel--;
+				if ( sel > OK )
+				{
+					sel = OK;
+				}
+			}
+			
+			if ( Joystick.IsRight() )
+			{
+				bRedraw = true;
+				bDrawButtons = true;
+				sel++;
+				if ( sel > OK )
+				{
+					sel = TARGETPH;
+				}
+			}
+			
+			if ( Joystick.IsButtonPressed() )
+			{
+				if ( sel == OK || sel == TARGETPH)
+				{
+					bDone = true;
+					bSave = true;
+				}
+				else if ( sel == CANCEL )
+				{
+					bDone = true;
+				}
+			}
+		} while ( ! bDone );
+    }
+	
+    ClearScreen(DefaultBGColor);
+	
+	if ( bSave )
+	{
+		if(iTarget[0] == 7 && iTarget[1] == 10)
+		{
+			PHMin = iValue[0];
+			PHMax = iValue[1];
+		} 
+		else 
+		{
+			if(iTarget[0] == 7)
+			{
+				PHMin = iValue[0];
+				PHMax = LinearInterpolation(10.0, iTarget[0], iValue[0], iTarget[1], iValue[1]);
+			}
+			else if(iTarget[1] == 10)
+			{
+				PHMin = LinearInterpolation(7.0, iTarget[0], iValue[0], iTarget[1], iValue[1]);
+				PHMax = iValue[1];
+			} 
+			else 
+			{
+				PHMin = LinearInterpolation(7.0, iTarget[0], iValue[0], iTarget[1], iValue[1]);
+				PHMax = LinearInterpolation(10.0, iTarget[0], iValue[0], iTarget[1], iValue[1]);
+			}
+		}
+        // save PHMin & PHMax to memory
+        InternalMemory.PHMin_write(PHMin);
+        InternalMemory.PHMax_write(PHMax);
+	}
+}
+#endif // SetupCalibrateChoicePH
 
 #ifdef SALINITYEXPANSION
 void ReefAngelClass::SetupCalibrateSalinity()
@@ -3542,7 +3866,7 @@ void ReefAngelClass::SetupCalibrateWaterLevel()
 }
 #endif  // WATERLEVELEXPANSION
 
-#ifdef DateTimeSetup
+#if defined DateTimeSetup && !defined DATETIME24
 void ReefAngelClass::SetupDateTime()
 {
     enum choices {
@@ -3882,6 +4206,403 @@ void ReefAngelClass::SetupDateTime()
     }
 }
 #endif  // DateTimeSetup
+
+
+#ifdef DATETIME24
+void ReefAngelClass::SetupDateTime24()
+{
+    enum choices {
+        MONTH,
+        DAY,
+        YEAR,
+        HOUR,
+        MINUTE,
+        TIMEFORMAT,
+        OK,
+        CANCEL
+    };
+    byte sel = MONTH;
+    bool bSave = false;
+    bool bDone = false;
+    bool bRedraw = true;
+    bool bDrawButtons = true;
+    byte Year, Month, Day, Hour, Minute;
+    byte MonthDays[13] = {0,31,28,31,30,31,30,31,31,30,31,30,31};
+	uint8_t iTimeformat;
+    byte DateRow = 35, TimeRow = 60, FormatRow = 85;
+
+    Year = year() - 2000;
+    Month = month();
+    Day = day();
+    Hour = hour();
+    Minute = minute();
+	iTimeformat = InternalMemory.TimeUse12Hour_read() ? 12 : 24;
+
+    ClearScreen(DefaultBGColor);
+    LCD.DrawText(DefaultFGColor, DefaultBGColor, MENU_START_COL, MENU_START_ROW, "Set Date & Time");
+    LCD.DrawText(DefaultFGColor, DefaultBGColor, 10, DateRow,"Date:");
+    LCD.DrawText(DefaultFGColor, DefaultBGColor, 10, TimeRow,"Time:");
+    LCD.DrawText(DefaultFGColor, DefaultBGColor, 10, FormatRow,"Format:");
+    LCD.DrawText(DefaultFGColor, DefaultBGColor, 62, DateRow, "/");
+    LCD.DrawText(DefaultFGColor, DefaultBGColor, 82, DateRow, "/");
+    LCD.DrawText(DefaultFGColor, DefaultBGColor, 82, TimeRow, ":");
+    LCD.DrawText(DefaultFGColor, DefaultBGColor, 95, FormatRow, "H");
+
+    do
+    {
+#if defined WDT || defined WDT_FORCE
+		wdt_reset();
+#endif  // defined WDT || defined WDT_FORCE
+        if ( bRedraw )
+        {
+            switch ( sel )
+            {
+                case MONTH:
+                {
+                    LCD.DrawOption(Month, 1, 49, DateRow, "", "", 2);
+                    LCD.DrawOption(Day, 0, 69, DateRow, "", "", 2);
+                    LCD.DrawOption(Year, 0, 89, DateRow, "", "", 2);
+                    LCD.DrawOption(Hour, 0, 69, TimeRow, "", "", 2);
+                    LCD.DrawOption(Minute, 0, 89, TimeRow, "", "", 2);
+					LCD.DrawOption(iTimeformat, 0, 82, FormatRow, "", "", 2);
+                    if ( bDrawButtons )
+                    {
+                        LCD.DrawOK(false);
+                        LCD.DrawCancel(false);
+                    }
+                    break;
+                }
+                case DAY:
+                {
+                    LCD.DrawOption(Month, 0, 49, DateRow, "", "", 2);
+                    LCD.DrawOption(Day, 1, 69, DateRow, "", "", 2);
+                    LCD.DrawOption(Year, 0, 89, DateRow, "", "", 2);
+                    LCD.DrawOption(Hour, 0, 69, TimeRow, "", "", 2);
+                    LCD.DrawOption(Minute, 0, 89, TimeRow, "", "", 2);
+					LCD.DrawOption(iTimeformat, 0, 82, FormatRow, "", "", 2);
+                    if ( bDrawButtons )
+                    {
+                        LCD.DrawOK(false);
+                        LCD.DrawCancel(false);
+                    }
+                    break;
+                }
+                case YEAR:
+                {
+                    LCD.DrawOption(Month, 0, 49, DateRow, "", "", 2);
+                    LCD.DrawOption(Day, 0, 69, DateRow, "", "", 2);
+                    LCD.DrawOption(Year, 1, 89, DateRow, "", "", 2);
+                    LCD.DrawOption(Hour, 0, 69, TimeRow, "", "", 2);
+                    LCD.DrawOption(Minute, 0, 89, TimeRow, "", "", 2);
+					LCD.DrawOption(iTimeformat, 0, 82, FormatRow, "", "", 2);
+                    if ( bDrawButtons )
+                    {
+                        LCD.DrawOK(false);
+                        LCD.DrawCancel(false);
+                    }
+                    break;
+                }
+                case HOUR:
+                {
+                    LCD.DrawOption(Month, 0, 49, DateRow, "", "", 2);
+                    LCD.DrawOption(Day, 0, 69, DateRow, "", "", 2);
+                    LCD.DrawOption(Year, 0, 89, DateRow, "", "", 2);
+                    LCD.DrawOption(Hour, 1, 69, TimeRow, "", "", 2);
+                    LCD.DrawOption(Minute, 0, 89, TimeRow, "", "", 2);
+					LCD.DrawOption(iTimeformat, 0, 82, FormatRow, "", "", 2);
+                    if ( bDrawButtons )
+                    {
+                        LCD.DrawOK(false);
+                        LCD.DrawCancel(false);
+                    }
+                    break;
+                }
+                case MINUTE:
+                {
+                    LCD.DrawOption(Month, 0, 49, DateRow, "", "", 2);
+                    LCD.DrawOption(Day, 0, 69, DateRow, "", "", 2);
+                    LCD.DrawOption(Year, 0, 89, DateRow, "", "", 2);
+                    LCD.DrawOption(Hour, 0, 69, TimeRow, "", "", 2);
+                    LCD.DrawOption(Minute, 1, 89, TimeRow, "", "", 2);
+					LCD.DrawOption(iTimeformat, 0, 82, FormatRow, "", "", 2);
+                    if ( bDrawButtons )
+                    {
+                        LCD.DrawOK(false);
+                        LCD.DrawCancel(false);
+                    }
+                    break;
+                }
+
+				case TIMEFORMAT:
+				{
+					
+                    LCD.DrawOption(Month, 0, 49, DateRow, "", "", 2);
+                    LCD.DrawOption(Day, 0, 69, DateRow, "", "", 2);
+                    LCD.DrawOption(Year, 0, 89, DateRow, "", "", 2);
+                    LCD.DrawOption(Hour, 0, 69, TimeRow, "", "", 2);
+                    LCD.DrawOption(Minute, 0, 89, TimeRow, "", "", 2);
+                    LCD.DrawOption(iTimeformat, 1, 82, FormatRow, "", "", 2);
+                    if ( bDrawButtons )
+                    {
+                        LCD.DrawOK(false);
+                        LCD.DrawCancel(false);
+                    }
+					break;
+				}
+                case OK:
+                {
+                    if ( bDrawButtons )
+                    {
+                        LCD.DrawOption(Month, 0, 49, DateRow, "", "", 2);
+                        LCD.DrawOption(Day, 0, 69, DateRow, "", "", 2);
+                        LCD.DrawOption(Year, 0, 89, DateRow, "", "", 2);
+                        LCD.DrawOption(Hour, 0, 69, TimeRow, "", "", 2);
+                        LCD.DrawOption(Minute, 0, 89, TimeRow, "", "", 2);
+						LCD.DrawOption(iTimeformat, 0, 82, FormatRow, "", "", 2);
+                        LCD.DrawOK(true);
+                        LCD.DrawCancel(false);
+                    }
+                    break;
+                }
+                case CANCEL:
+                {
+                    if ( bDrawButtons )
+                    {
+                        LCD.DrawOption(Month, 0, 49, DateRow, "", "", 2);
+                        LCD.DrawOption(Day, 0, 69, DateRow, "", "", 2);
+                        LCD.DrawOption(Year, 0, 89, DateRow, "", "", 2);
+                        LCD.DrawOption(Hour, 0, 69, TimeRow, "", "", 2);
+                        LCD.DrawOption(Minute, 0, 89, TimeRow, "", "", 2);
+						LCD.DrawOption(iTimeformat, 0, 82, FormatRow, "", "", 2);
+                        LCD.DrawOK(false);
+                        LCD.DrawCancel(true);
+                    }
+                    break;
+                }
+            }
+
+            bRedraw = false;
+            bDrawButtons = false;
+        }
+        if ( Joystick.IsUp() )
+        {
+            switch ( sel )
+            {
+                case MONTH:
+                {
+                    Month++;
+                    if ( Month > 12 )
+                    {
+                        Month = 1;
+                    }
+                    break;
+                }
+                case DAY:
+                {
+                    Day++;
+                    // lookup days in a month table
+                    if ( ! IsLeapYear(2000+Year) )
+                    {
+                        // not leap year
+                        if ( Day > MonthDays[Month] )
+                        {
+                            Day = 1;
+                        }
+                    }
+                    else
+                    {
+                        // leap year, only special case is February
+                        if ( Month == 2 )
+                        {
+                            if ( Day > 29 )
+                            {
+                                Day = 1;
+                            }
+                        }
+                        else
+                        {
+                            if ( Day > MonthDays[Month] )
+                            {
+                                Day = 1;
+                            }
+                        }
+                    }
+                    break;
+                }
+                case YEAR:
+                {
+                    Year++;
+                    if ( Year > 99 )
+                    {
+                        Year = 0;
+                    }
+                    break;
+                }
+                case HOUR:
+                {
+                    Hour++;
+                    if ( Hour > 23 )
+                    {
+                        Hour = 0;
+                    }
+                    break;
+                }
+                case MINUTE:
+                {
+                    Minute++;
+                    if ( Minute > 59 )
+                    {
+                        Minute = 0;
+                    }
+                    break;
+                }
+
+				case TIMEFORMAT:
+				{
+
+					iTimeformat += 12;
+					if(iTimeformat > 24)
+					{
+
+						iTimeformat = 24;
+					}
+					break;
+				}
+            }
+            bRedraw = true;
+        }
+        if ( Joystick.IsDown() )
+        {
+            switch ( sel )
+            {
+                case MONTH:
+                {
+                    Month--;
+                    if ( Month < 1 || Month > 12 )
+                    {
+                        Month = 12;
+                    }
+                    break;
+                }
+                case DAY:
+                {
+                    Day--;
+                    // lookup days in a month table
+                    if ( ! IsLeapYear(2000+Year) )
+                    {
+                        // not leap year
+                        if ( Day < 1 || Day > MonthDays[Month] )
+                        {
+                            Day = MonthDays[Month];
+                        }
+                    }
+                    else
+                    {
+                        // leap year, only special case is February
+                        if ( Month == 2 )
+                        {
+                            if ( Day < 1 || Day > MonthDays[Month] )
+                            {
+                                Day = 29;
+                            }
+                        }
+                        else
+                        {
+                            if ( Day < 1 || Day > MonthDays[Month] )
+                            {
+                                Day = MonthDays[Month];
+                            }
+                        }
+                    }
+                    break;
+                }
+                case YEAR:
+                {
+                    Year--;
+                    if ( Year > 99 )
+                    {
+                        Year = 99;
+                    }
+                    break;
+                }
+                case HOUR:
+                {
+                    Hour--;
+                    if ( Hour > 23 )
+                    {
+                        Hour = 23;
+                    }
+                    break;
+                }
+                case MINUTE:
+                {
+                    Minute--;
+                    if ( Minute > 59 )
+                    {
+                        Minute = 59;
+                    }
+                    break;
+                }
+
+				case TIMEFORMAT:
+				{
+
+					iTimeformat -= 12;
+					if(iTimeformat < 12)
+					{
+
+						iTimeformat = 12;
+					}
+					break;
+				}
+            }
+            bRedraw = true;
+        }
+        if ( Joystick.IsLeft() )
+        {
+            bRedraw = true;
+            bDrawButtons = true;
+            sel--;
+            if ( sel > CANCEL )
+            {
+                sel = CANCEL;
+            }
+        }
+        if ( Joystick.IsRight() )
+        {
+            bRedraw = true;
+            bDrawButtons = true;
+            sel++;
+            if ( sel > CANCEL )
+            {
+                sel = MONTH;
+            }
+        }
+        if ( Joystick.IsButtonPressed() )
+        {
+            if ( sel == OK )
+            {
+                bDone = true;
+                bSave = true;
+            }
+            else if ( sel == CANCEL )
+            {
+                bDone = true;
+            }
+        }
+    } while ( ! bDone );
+
+    if ( bSave )
+    {
+        // Set Date & Time
+        setTime(Hour, Minute, 0, Day, Month, Year);
+        now();
+        RTC.set(now());
+		InternalMemory.TimeUse12Hour_write(iTimeformat == 12);
+    }
+}
+
+#endif  // DATETIME24
 
 #if !defined SIMPLE_MENU && !defined CUSTOM_MENU
 #ifdef DosingPumpSetup

--- a/ReefAngel/ReefAngel.h
+++ b/ReefAngel/ReefAngel.h
@@ -22,7 +22,7 @@
 #ifndef	__REEFANGEL_H__
 #define __REEFANGEL_H__
 
-#define ReefAngel_Version "0.9.9"
+#define ReefAngel_Version "1.0.1"
 
 #include <Globals.h>
 #include <InternalEEPROM.h>  // NOTE read/write internal memory
@@ -267,6 +267,7 @@ public:
 #endif  // CUSTOM_MENU
 
     void SetupCalibratePH();
+    void SetupCalibrateChoicePH();
 #if defined ORPEXPANSION
     void SetupCalibrateORP();
 #endif  // defined ORPEXPANSION
@@ -279,9 +280,12 @@ public:
 #if defined WATERLEVELEXPANSION
     void SetupCalibrateWaterLevel();
 #endif  // defined WATERLEVELEXPANSION
-#ifdef DateTimeSetup
+#if defined DateTimeSetup && !defined DATETIME24
     void SetupDateTime();
 #endif  // DateTimeSetup
+#ifdef DATETIME24
+    void SetupDateTime24();
+#endif  // DATETIME24
 #if !defined SIMPLE_MENU && !defined CUSTOM_MENU
 #ifdef DosingPumpSetup
     void SetupDosingPump();

--- a/ReefAngel/keywords.txt
+++ b/ReefAngel/keywords.txt
@@ -18,6 +18,7 @@ PWMParabola	KEYWORD2
 MoonPhase	KEYWORD2
 ConvertNumToString	KEYWORD2
 pingSerial	KEYWORD2
+MoonPhaseLabel	KEYWORD2
 
 # ReefAngel
 
@@ -30,6 +31,7 @@ AddWifi	KEYWORD2
 StandardLights	KEYWORD2
 AddRFExpansion	KEYWORD2
 AddDateTimeMenu	KEYWORD2
+DayLights	KEYWORD2
 DelayedStartLights	KEYWORD2
 ActinicLights	KEYWORD2
 MoonLights	KEYWORD2
@@ -424,6 +426,7 @@ Temp	LITERAL2
 PH	LITERAL2
 Salinity	LITERAL2
 ORP	LITERAL2
+PHExp	LITERAL2
 DisplayedMenu	LITERAL2
 FeedingModePorts	LITERAL2
 FeedingModePortsE	LITERAL2


### PR DESCRIPTION
Adds the method SetupDateTime24 with the option to select between 12h and 24h. If 24h selected it renders date and time according to ISO 8601.
Ex. 2012-06-27 19:00

SetupDateTime24 is activated with define "DATETIME24".

This is pretty much the same as my previous pull request (#29) but squashed into one single commit. Hopefully that will make it easier to review.

I pulled the changes from 1.0.1 so it should be reasonably up to date and simple to merge unless I screwed something up with git (and that wouldn't surprise me at all)...

Below are my compile sizes with different options:
29448   1.0.1       RA
29448   patch   RA
29816   patch   RA      w DATETIME24
31246   patch   RA+
31602   patch   RA+     w DATETIME24
