### PR TITLE
Increase waterlevel constraint

### DIFF
--- a/WaterLevel/WaterLevel.cpp
+++ b/WaterLevel/WaterLevel.cpp
@@ -50,7 +50,7 @@ byte WaterLevelClass::GetLevel()
 	if (t!=0)
 	{
 		t=map(t, InternalMemory.WaterLevelMin_read(), InternalMemory.WaterLevelMax_read(), 0, 100); // apply the calibration to the sensor reading
-		t=constrain(t,0,100);
+		t=constrain(t,0,200);
 	}
 	return t;
 }


### PR DESCRIPTION
Increasing the constraint of the waterlevel from 100 to 200. The reason for this is that it might be good to know values above 100%. For example if I fill up my osmosis to 104% it's going to overflow into the sump and if it reaches up to about 108% it will overflow on the floor... There can of course be a lot more scenarios when this info is needed and I don't see any reason to limit it to just 100%.
