### PR TITLE
Switch from Water change directly to Feed mode

### DIFF
--- a/RA_Wifi/RA_Wifi.cpp
+++ b/RA_Wifi/RA_Wifi.cpp
@@ -640,8 +640,8 @@ void processHTTP()
 			}
 			case REQ_FEEDING:
 			{
-				// Start up the feeding mode only if we are on the home screen
-				if ( ReefAngel.DisplayedMenu == DEFAULT_MENU )
+				// Start up the feeding mode only if we are on the home screen or from Water change
+				if ( ReefAngel.DisplayedMenu == DEFAULT_MENU || ReefAngel.DisplayedMenu==WATERCHANGE_MODE )
 				{
 					//ReefAngel.ClearScreen(DefaultBGColor);
 					ReefAngel.FeedingModeStart();


### PR DESCRIPTION
Makes it possible to change mode directly from Water change to Feed mode over wifi. Sometimes I might do the feeding of anemones, riccordeas etc in Water change mode because on that mode the power heads are always of. After the actual feeding I would like to change to Feeding mode on the RA so the power heads are set to low flow for a couple of minutes before going back to normal mode.

Prior to this fix it can only be done by exiting Water change mode and then quickly enter Feed mode.
