### PR TITLE
Added OverridePort variables to remove any mask requests for a port.

### DIFF
--- a/RA_Wifi/RA_Wifi.cpp
+++ b/RA_Wifi/RA_Wifi.cpp
@@ -269,6 +269,19 @@ void processHTTP()
 					}
 #endif  // RelayExp
 				}
+#ifdef OVERRIDE_PORTS
+				// Reset relay masks for ports we want always in their programmed states.
+				ReefAngel.Relay.RelayMaskOn &= ~ReefAngel.OverridePorts;
+				ReefAngel.Relay.RelayMaskOff |= ReefAngel.OverridePorts;
+#ifdef RelayExp
+			        byte i;
+			        for ( i = 0; i < MAX_RELAY_EXPANSION_MODULES; i++ )
+			        {
+			                ReefAngel.Relay.RelayMaskOnE[i] &= ~ReefAngel.OverridePortsE[i];
+			                ReefAngel.Relay.RelayMaskOffE[i] |= ReefAngel.OverridePortsE[i];
+			        }
+#endif  // RelayExp  
+#endif  // OVERRIDE_PORTS
 				ReefAngel.Relay.Write();
 				// Force update of the Portal after relay change
 //				ReefAngel.Timer[PORTAL_TIMER].ForceTrigger();

--- a/ReefAngel/ReefAngel.cpp
+++ b/ReefAngel/ReefAngel.cpp
@@ -649,6 +649,11 @@ void ReefAngelClass::Init()
     //                 Port 87654321
     OverheatShutoffPorts = B00000100;
 
+#ifdef OVERRIDE_PORTS
+    // Override all relay masks for the following ports
+    OverridePorts = 0;
+#endif // OVERRIDE_PORTS
+
     // DelayedOn ports, do not manually modify this variable, let the DelayedOn function modify it
     DelayedOnPorts = 0;
 
@@ -660,6 +665,10 @@ void ReefAngelClass::Init()
 		WaterChangePortsE[i] = 0;
 		OverheatShutoffPortsE[i] = 0;
 		DelayedOnPortsE[i] = 0;
+#ifdef OVERRIDE_PORTS
+		// Override all relay masks for the following ports
+		OverridePortsE[i] = 0;
+#endif // OVERRIDE_PORTS
 #ifndef RemoveAllLights
 		LightsOnPortsE[i] = 0;
 #endif  // RemoveAllLights
@@ -799,6 +808,20 @@ void ReefAngelClass::Refresh()
 	IO.GetChannel();
 #endif  // IOEXPANSION
 #endif  // REEFTOUCHDISPLAY	
+
+#ifdef OVERRIDE_PORTS
+	// Reset relay masks for ports we want always in their programmed states.
+	ReefAngel.Relay.RelayMaskOn &= ~OverridePorts;
+	ReefAngel.Relay.RelayMaskOff |= OverridePorts;
+#ifdef RelayExp
+        byte i;
+        for ( i = 0; i < MAX_RELAY_EXPANSION_MODULES; i++ )
+        {
+                Relay.RelayMaskOnE[i] &= ~OverridePortsE[i];
+                Relay.RelayMaskOffE[i] |= OverridePortsE[i];
+        }
+#endif  // RelayExp  
+#endif  // OVERRRIDE_PORTS	
 	
 	Relay.Write();
 	if (ds.read_bit()==0) return;  // ds for OneWire TempSensor

--- a/ReefAngel/ReefAngel.h
+++ b/ReefAngel/ReefAngel.h
@@ -254,6 +254,9 @@ public:
 	byte FeedingModePorts;
 	byte WaterChangePorts;
 	byte OverheatShutoffPorts;
+#ifdef OVERRIDE_PORTS
+	byte OverridePorts;
+#endif
 	byte EM;
 	byte REM;
 	
@@ -262,6 +265,9 @@ public:
 	byte FeedingModePortsE[MAX_RELAY_EXPANSION_MODULES];
 	byte WaterChangePortsE[MAX_RELAY_EXPANSION_MODULES];
 	byte OverheatShutoffPortsE[MAX_RELAY_EXPANSION_MODULES];
+#ifdef OVERRIDE_PORTS
+  byte OverridePortsE[MAX_RELAY_EXPANSION_MODULES];
+#endif  // OVERRIDE_PORTS
 #endif  // RelayExp
 #ifndef RemoveAllLights
 	byte LightsOnPorts;
@@ -294,6 +300,7 @@ public:
 	void inline AddRFExpansion() {};
 	void inline AddCustomColors() {};
 	void inline AddBusCheck() {};
+        void inline AddPortOverrides() {};
 	void inline Display24h() {};
 	void inline UseFlexiblePhCalibration() {};
 	void inline Mini() {}; // deprecated

--- a/ReefAngel/keywords.txt
+++ b/ReefAngel/keywords.txt
@@ -41,6 +41,7 @@ AddDateTimeMenu	KEYWORD2
 AddCustomColors	KEYWORD2
 AddBusCheck	KEYWORD2
 Display24h	KEYWORD2
+AddPortOverrides	KEYWORD2
 One	KEYWORD2
 Mini	KEYWORD2
 DayLights	KEYWORD2


### PR DESCRIPTION
This will discard any changes made through the relay masks for the specified ports.

To activate the feature use the following function:

  ReefAngel.AddPortOverrides();

To make use of this functionality the following variables have been added the ReefAngel class:

ReefAngel.OverridePorts
ReefAngel.OverridePortsE[]

The following line needs to be added to feature.txt

OVERRIDE_PORTS,ReefAngel.AddPortOverrides,Override Port Masks
