### PR TITLE
Issue 142: Changes to DCPump class and methods

### DIFF
--- a/DCPump/DCPump.cpp
+++ b/DCPump/DCPump.cpp
@@ -30,11 +30,20 @@ DCPumpClass::DCPumpClass()
 	DaylightChannel=None;
 	ActinicChannel=None;
 	LowATOChannel=None;
+	HighATOChannel=None;
+#ifdef RFEXPANSION
+	Threshold=0;
+#else //RFEXPANSION
 	Threshold=30;
+#endif // RFEXPANSION
+
 #ifdef PWMEXPANSION
 	for (int a=0;a<PWM_EXPANSION_CHANNELS;a++)
 		ExpansionChannel[a]=None;
 #endif // PWMEXPANSION
+  if (InternalMemory.DCPumpThreshold_read() > 100) InternalMemory.DCPumpThreshold_write(Threshold); // if it has never been initialized, 
+                                                                                             // it will be at 255 and will need to be set to something sensible
+                                                                                             // like a default of 30 percent
 }
 
 void DCPumpClass::SetMode(byte mode, byte speed, byte duration)
@@ -42,7 +51,6 @@ void DCPumpClass::SetMode(byte mode, byte speed, byte duration)
 	 Mode=mode;
 	 Speed=speed;
 	 Duration=duration;
-         Threshold=30;
 }
 
 void DCPumpClass::SetMode(byte mode, byte speed, byte duration, byte threshold)

--- a/DCPump/DCPump.h
+++ b/DCPump/DCPump.h
@@ -22,6 +22,8 @@
 #ifndef __DCPump_H__
 #define __DCPump_H__
 
+#include <InternalEEPROM.h>
+
 class DCPumpClass
 {
 public:
@@ -34,6 +36,7 @@ public:
 	 byte DaylightChannel;
 	 byte ActinicChannel;
 	 byte LowATOChannel;
+	 byte HighATOChannel;
 	 byte FeedingSpeed;
 	 byte WaterChangeSpeed;
 #ifdef PWMEXPANSION

--- a/Globals/Globals.h
+++ b/Globals/Globals.h
@@ -944,6 +944,12 @@ Used by the RF Expansion Module
 #define None          99
 #define Radion        100
 
+/*
+ * Non-Vortech DC Pump modes added, using unused integers, else matched to U-App development
+ */
+#define Else		12
+#define Sine 		13
+
 // Radion Channels
 #define Radion_White      0
 #define Radion_RoyalBlue  1

--- a/RA_Wifi/RA_Wifi.cpp
+++ b/RA_Wifi/RA_Wifi.cpp
@@ -435,11 +435,12 @@ void RA_Wifi::ProcessHTTP()
 			s += intlength(ReefAngel.PAR.GetLevel());
 #endif  // PAREXPANSION
 #ifdef DCPUMPCONTROL
-			s += 33;
-			//<DCM></DCM><DCS></DCS><DCD></DCD>
+			s += 44;
+			//<DCM></DCM><DCS></DCS><DCD></DCD><DCT></DCT>
 			s += intlength(ReefAngel.DCPump.Mode);
 			s += intlength(ReefAngel.DCPump.Speed);
 			s += intlength(ReefAngel.DCPump.Duration);
+			s += intlength(ReefAngel.DCPump.Threshold);
 #endif  // DCPUMPCONTROL
 #ifdef IOEXPANSION
 			s += 9;
@@ -1036,11 +1037,12 @@ void RA_Wifi::ProcessHTTP()
 			s += intlength(ReefAngel.PAR.GetLevel());
 #endif  // PAREXPANSION
 #ifdef DCPUMPCONTROL
-			s += 27;
-			//,"DCM":"","DCS":"","DCD":""
+			s += 36;
+			//,"DCM":"","DCS":"","DCD":"","DCT":""
 			s += intlength(ReefAngel.DCPump.Mode);
 			s += intlength(ReefAngel.DCPump.Speed);
 			s += intlength(ReefAngel.DCPump.Duration);
+			s += intlength(ReefAngel.DCPump.Threshold);
 #endif  // DCPUMPCONTROL
 #ifdef IOEXPANSION
 			s += 8;
@@ -1311,6 +1313,8 @@ void RA_Wifi::SendXMLData(bool fAtoLog /*= false*/)
 	PROGMEMprint(XML_DCS_END);
 	print(ReefAngel.DCPump.Duration, DEC);
 	PROGMEMprint(XML_DCD_END);
+	print(ReefAngel.DCPump.Threshold, DEC);
+	PROGMEMprint(XML_DCT_END);
 #endif  // DCPUMPCONTROL
 #ifdef IOEXPANSION
 	PROGMEMprint(XML_IO);
@@ -1572,6 +1576,7 @@ void RA_Wifi::SendJSONData()
 	SendSingleJSON(JSON_DCM,ReefAngel.DCPump.Mode);
 	SendSingleJSON(JSON_DCS,ReefAngel.DCPump.Speed);
 	SendSingleJSON(JSON_DCD,ReefAngel.DCPump.Duration);
+	SendSingleJSON(JSON_DCT,ReefAngel.DCPump.Threshold);
 #endif  // DCPUMPCONTROL
 #ifdef IOEXPANSION
 	SendSingleJSON(JSON_IO,ReefAngel.IO.GetChannel());
@@ -1948,6 +1953,8 @@ void RA_Wifi::SendPortal(char *username, char*key)
   print(ReefAngel.DCPump.Speed, DEC);
   PROGMEMprint(BannerDCD);
   print(ReefAngel.DCPump.Duration, DEC);
+  PROGMEMprint(BannerDCT);
+  print(ReefAngel.DCPump.Threshold, DEC);
 #endif  // DCPUMPCONTROL
 #ifdef IOEXPANSION
   PROGMEMprint(BannerIO);

--- a/RA_Wifi/RA_Wifi.h
+++ b/RA_Wifi/RA_Wifi.h
@@ -84,7 +84,8 @@ const prog_char XML_PAR_END[] PROGMEM = "</PAR>";
 const prog_char XML_DCM[] PROGMEM = "<DCM>";
 const prog_char XML_DCM_END[] PROGMEM = "</DCM><DCS>";
 const prog_char XML_DCS_END[] PROGMEM = "</DCS><DCD>";
-const prog_char XML_DCD_END[] PROGMEM = "</DCD>";
+const prog_char XML_DCD_END[] PROGMEM = "</DCD><DCT>";
+const prog_char XML_DCT_END[] PROGMEM = "</DCT>";
 #endif  // DCPUMPCONTROL
 #ifdef PWMEXPANSION
 const prog_char XML_PWME[] PROGMEM = "<PWME";
@@ -212,6 +213,7 @@ const prog_char JSON_PAR[] PROGMEM = "PAR";
 const prog_char JSON_DCM[] PROGMEM = "DCM";
 const prog_char JSON_DCS[] PROGMEM = "DCS";
 const prog_char JSON_DCD[] PROGMEM = "DCD";
+const prog_char JSON_DCT[] PROGMEM = "DCT";
 #endif  // DCPUMPCONTROL
 #ifdef PWMEXPANSION
 const prog_char JSON_PWME[] PROGMEM = "PWME";
@@ -367,6 +369,7 @@ const prog_char BannerSubdomain[] PROGMEM = "&ddns=";
 	const prog_char BannerDCM[] PROGMEM = "&dcm=";
 	const prog_char BannerDCS[] PROGMEM = "&dcs=";
 	const prog_char BannerDCD[] PROGMEM = "&dcd=";
+	const prog_char BannerDCT[] PROGMEM = "&dct=";
 #endif  // DCPUMPCONTROL
 
 #ifdef CUSTOM_VARIABLES

--- a/ReefAngel/ReefAngel.cpp
+++ b/ReefAngel/ReefAngel.cpp
@@ -285,6 +285,8 @@ void ReefAngelClass::Refresh()
 #endif
 		if (DCPump.LowATOChannel!=None)
 			analogWrite(lowATOPin, 2.55*PumpThreshold(DCPump.Speed,DCPump.Threshold));
+		if (DCPump.HighATOChannel!=None)
+			analogWrite(highATOPin, 2.55*PumpThreshold(DCPump.Speed,DCPump.Threshold));
 #ifdef PWMEXPANSION
 		for (int a=0; a<PWM_EXPANSION_CHANNELS;a++)
 			if (DCPump.ExpansionChannel[a]!=None)
@@ -312,6 +314,8 @@ void ReefAngelClass::Refresh()
 #endif
 		if (DCPump.LowATOChannel!=None)
 			analogWrite(lowATOPin, 2.55*PumpThreshold(ReefCrestMode(DCPump.Speed,10,DCPump.LowATOChannel-1),DCPump.Threshold));
+		if (DCPump.HighATOChannel!=None)
+			analogWrite(highATOPin, 2.55*PumpThreshold(ReefCrestMode(DCPump.Speed,10,DCPump.HighATOChannel-1),DCPump.Threshold));
 #ifdef PWMEXPANSION
 		for (int a=0; a<PWM_EXPANSION_CHANNELS;a++)
 			if (DCPump.ExpansionChannel[a]!=None)
@@ -339,6 +343,8 @@ void ReefAngelClass::Refresh()
 #endif
 		if (DCPump.LowATOChannel!=None)
 			analogWrite(lowATOPin, 2.55*PumpThreshold(ReefCrestMode(DCPump.Speed,20,DCPump.LowATOChannel-1),DCPump.Threshold));
+		if (DCPump.HighATOChannel!=None)
+			analogWrite(highATOPin, 2.55*PumpThreshold(ReefCrestMode(DCPump.Speed,20,DCPump.HighATOChannel-1),DCPump.Threshold));
 #ifdef PWMEXPANSION
 		for (int a=0; a<PWM_EXPANSION_CHANNELS;a++)
 			if (DCPump.ExpansionChannel[a]!=None)
@@ -366,6 +372,8 @@ void ReefAngelClass::Refresh()
 #endif
 		if (DCPump.LowATOChannel!=None)
 			analogWrite(lowATOPin, 2.55*PumpThreshold(ShortPulseMode(0,DCPump.Speed,DCPump.Duration*10,DCPump.LowATOChannel-1),DCPump.Threshold));
+		if (DCPump.HighATOChannel!=None)
+			analogWrite(highATOPin, 2.55*PumpThreshold(ShortPulseMode(0,DCPump.Speed,DCPump.Duration*10,DCPump.HighATOChannel-1),DCPump.Threshold));
 #ifdef PWMEXPANSION
 		for (int a=0; a<PWM_EXPANSION_CHANNELS;a++)
 			if (DCPump.ExpansionChannel[a]!=None)
@@ -393,6 +401,8 @@ void ReefAngelClass::Refresh()
 #endif
 		if (DCPump.LowATOChannel!=None)
 			analogWrite(lowATOPin, 2.55*PumpThreshold(LongPulseMode(0,DCPump.Speed,DCPump.Duration,DCPump.LowATOChannel-1),DCPump.Threshold));
+		if (DCPump.HighATOChannel!=None)
+			analogWrite(highATOPin, 2.55*PumpThreshold(LongPulseMode(0,DCPump.Speed,DCPump.Duration,DCPump.HighATOChannel-1),DCPump.Threshold));
 #ifdef PWMEXPANSION
 		for (int a=0; a<PWM_EXPANSION_CHANNELS;a++)
 			if (DCPump.ExpansionChannel[a]!=None)
@@ -420,6 +430,8 @@ void ReefAngelClass::Refresh()
 #endif
 		if (DCPump.LowATOChannel!=None)
 			analogWrite(lowATOPin, 2.55*PumpThreshold(NutrientTransportMode(0,DCPump.Speed,DCPump.Duration*10,DCPump.LowATOChannel-1),DCPump.Threshold));
+		if (DCPump.HighATOChannel!=None)
+			analogWrite(highATOPin, 2.55*PumpThreshold(NutrientTransportMode(0,DCPump.Speed,DCPump.Duration*10,DCPump.HighATOChannel-1),DCPump.Threshold));
 #ifdef PWMEXPANSION
 		for (int a=0; a<PWM_EXPANSION_CHANNELS;a++)
 			if (DCPump.ExpansionChannel[a]!=None)
@@ -447,6 +459,8 @@ void ReefAngelClass::Refresh()
 #endif
 		if (DCPump.LowATOChannel!=None)
 			analogWrite(lowATOPin, 2.55*PumpThreshold(TidalSwellMode(DCPump.Speed,DCPump.LowATOChannel-1),DCPump.Threshold));
+		if (DCPump.HighATOChannel!=None)
+			analogWrite(highATOPin, 2.55*PumpThreshold(TidalSwellMode(DCPump.Speed,DCPump.HighATOChannel-1),DCPump.Threshold));
 #ifdef PWMEXPANSION
 		for (int a=0; a<PWM_EXPANSION_CHANNELS;a++)
 			if (DCPump.ExpansionChannel[a]!=None)
@@ -455,6 +469,66 @@ void ReefAngelClass::Refresh()
 #else
 				PWM.SetChannel(a,PumpThreshold(TidalSwellMode(DCPump.Speed,DCPump.ExpansionChannel[a]-1),DCPump.Threshold));
 #endif
+#endif // PWMEXPANSION
+		break;
+	}
+	case Sine:
+	{
+		if (DCPump.DaylightChannel!=None)
+#if defined(__SAM3X8E__)
+			VariableControl.SetDaylight(PumpThreshold(SineMode(0,DCPump.Speed,DCPump.Duration,DCPump.DaylightChannel-1),DCPump.Threshold));
+#else // __SAM3X8E__
+			PWM.SetDaylight(PumpThreshold(SineMode(0,DCPump.Speed,DCPump.Duration,DCPump.DaylightChannel-1),DCPump.Threshold));
+#endif // __SAM3X8E__
+		if (DCPump.ActinicChannel!=None)
+#if defined(__SAM3X8E__)
+			VariableControl.SetActinic(PumpThreshold(SineMode(0,DCPump.Speed,DCPump.Duration,DCPump.ActinicChannel-1),DCPump.Threshold));
+#else // __SAM3X8E__
+			PWM.SetActinic(PumpThreshold(SineMode(0,DCPump.Speed,DCPump.Duration,DCPump.ActinicChannel-1),DCPump.Threshold));
+#endif // __SAM3X8E__
+		if (DCPump.LowATOChannel!=None)
+			analogWrite(lowATOPin, 2.55*PumpThreshold(SineMode(0,DCPump.Speed,DCPump.Duration,DCPump.LowATOChannel-1),DCPump.Threshold));
+		if (DCPump.HighATOChannel!=None)
+			analogWrite(highATOPin, 2.55*PumpThreshold(SineMode(0,DCPump.Speed,DCPump.Duration,DCPump.HighATOChannel-1),DCPump.Threshold));
+#ifdef PWMEXPANSION
+		for (int a=0; a<PWM_EXPANSION_CHANNELS;a++)
+			if (DCPump.ExpansionChannel[a]!=None)
+#if defined(__SAM3X8E__)
+				VariableControl.SetChannel(a,PumpThreshold(SineMode(0,DCPump.Speed,DCPump.Duration,DCPump.ExpansionChannel[a]-1),DCPump.Threshold));
+#else // __SAM3X8E__
+				PWM.SetChannel(a,PumpThreshold(SineMode(0,DCPump.Speed,DCPump.Duration,DCPump.ExpansionChannel[a]-1),DCPump.Threshold));
+#endif // __SAM3X8E__
+#endif // PWMEXPANSION
+		break;
+	}
+	case Else:
+	{
+		int offset = DCPump.Speed;
+		if (DCPump.Speed > 50) offset = 100 - DCPump.Speed;
+		if (DCPump.DaylightChannel!=None)
+#if defined(__SAM3X8E__)
+			VariableControl.SetDaylight(PumpThreshold(ElseMode(DCPump.Speed,offset,DCPump.DaylightChannel-1),DCPump.Threshold));
+#else // __SAM3X8E__
+			PWM.SetDaylight(PumpThreshold(ElseMode(DCPump.Speed,offset,DCPump.DaylightChannel-1),DCPump.Threshold));
+#endif // __SAM3X8E__
+		if (DCPump.ActinicChannel!=None)
+#if defined(__SAM3X8E__)
+			VariableControl.SetActinic(PumpThreshold(ElseMode(DCPump.Speed,offset,DCPump.ActinicChannel-1),DCPump.Threshold));
+#else // __SAM3X8E__
+			PWM.SetActinic(PumpThreshold(ElseMode(DCPump.Speed,offset,DCPump.ActinicChannel-1),DCPump.Threshold));
+#endif // __SAM3X8E__
+		if (DCPump.LowATOChannel!=None)
+			analogWrite(lowATOPin, 2.55*PumpThreshold(ElseMode(DCPump.Speed,offset,DCPump.LowATOChannel-1),DCPump.Threshold));
+		if (DCPump.HighATOChannel!=None)
+			analogWrite(highATOPin, 2.55*PumpThreshold(ElseMode(DCPump.Speed,offset,DCPump.HighATOChannel-1),DCPump.Threshold));
+#ifdef PWMEXPANSION
+		for (int a=0; a<PWM_EXPANSION_CHANNELS;a++)
+			if (DCPump.ExpansionChannel[a]!=None)
+#if defined(__SAM3X8E__)
+				VariableControl.SetChannel(a,PumpThreshold(ElseMode(DCPump.Speed,offset,DCPump.ExpansionChannel[a]-1),DCPump.Threshold));
+#else // __SAM3X8E__
+				PWM.SetChannel(a,PumpThreshold(ElseMode(DCPump.Speed,offset,DCPump.ExpansionChannel[a]-1),DCPump.Threshold));
+#endif // __SAM3X8E__
 #endif // PWMEXPANSION
 		break;
 	}
@@ -475,6 +549,8 @@ void ReefAngelClass::Refresh()
 #endif
 		if (DCPump.LowATOChannel!=None)
 			analogWrite(lowATOPin, 2.55*PumpThreshold(DCPump.FeedingSpeed,DCPump.Threshold));
+		if (DCPump.HighATOChannel!=None)
+			analogWrite(highATOPin, 2.55*PumpThreshold(DCPump.FeedingSpeed,DCPump.Threshold));
 #ifdef PWMEXPANSION
 		for (int a=0; a<PWM_EXPANSION_CHANNELS;a++)
 			if (DCPump.ExpansionChannel[a]!=None)
@@ -501,6 +577,8 @@ void ReefAngelClass::Refresh()
 #endif
 		if (DCPump.LowATOChannel!=None)
 			analogWrite(lowATOPin, 2.55*PumpThreshold(DCPump.WaterChangeSpeed,DCPump.Threshold));
+		if (DCPump.HighATOChannel!=None)
+			analogWrite(highATOPin, 2.55*PumpThreshold(DCPump.WaterChangeSpeed,DCPump.Threshold));
 #ifdef PWMEXPANSION
 		for (int a=0; a<PWM_EXPANSION_CHANNELS;a++)
 			if (DCPump.ExpansionChannel[a]!=None)


### PR DESCRIPTION
This pull addresses issue [#142](https://github.com/reefangel/Libraries/issues/142)

1) Added HighATO as an option for all DCPump modes
2) Added initialization for DCPump memory location of the Threshold
concept so if you're using internal memory with the RFExpansion module
enabled you will get a 0 written for threshold for the first time and if
you don't have an RFExpansion module enabled you'll get a 30 percent
written to the memory location.  This only happens the first time you
load the code that contains this new memory location (which is /mb364,
by the way).
3) Added defines for Else and Sine mode as DCPump modes and defined them
as mode 12 and 13, respectively, which matches what was added in U-App
as Else mode.  
Also added the code to do those modes in the switch/case statement in ReefAngel.cpp.
4) Outputting a new tag in the wifi output of <DCT> which reports the
threshold.  It comes in the XML and JSON right after <DCD> which is the
duration.

Tested with:

ReefAngel.DCPump.UseMemory = true;
ReefAngel.DCPump.DaylightChannel = Sync;
ReefAngel.DCPump.ActinicChannel = AntiSync;
ReefAngel.DCPump.LowATOChannel = Sync;
ReefAngel.DCPump.HighATOChannel = AntiSync;
