### PR TITLE
Issue 172: Fixing ReefCrest bug

### DIFF
--- a/Globals/Globals.cpp
+++ b/Globals/Globals.cpp
@@ -527,7 +527,7 @@ byte ReefCrestMode(byte WaveSpeed, byte WaveOffset, boolean PulseSync)
 	if (PulseSync)
 		return newspeed;
 	else
-		return WaveSpeed-(newspeed-WaveSpeed);
+		return constrain(WaveSpeed-(newspeed-WaveSpeed),0,100);
 }
 
 byte NutrientTransportMode(byte PulseMinSpeed, byte PulseMaxSpeed, int PulseDuration, boolean PulseSync)


### PR DESCRIPTION
Limiting ReefCrest so it doesn't go over 100 when pump is configured for
anti-sync.

I had DCPump.Speed set to 100 and the anti-sync pump was getting values
up to 120% since DCPump by default uses 20 as the offset for ReefCrest
mode.  Just added a constrain to prevent someone from making same
mistake I did.
