### PR TITLE
Fixed some typos for DaylightPWM2Parabola function

### DIFF
--- a/RA_PWM/RA_PWM.cpp
+++ b/RA_PWM/RA_PWM.cpp
@@ -528,7 +528,7 @@ void RA_PWMClass::Actinic2PWMParabola(int PreMinuteOffset, int PostMinuteOffset)
 
 void RA_PWMClass::Daylight2PWMParabola(int MinuteOffset)
 {
-	Daylight2PWMParabola(MinuteOffset, int MinuteOffset)
+	Daylight2PWMParabola(MinuteOffset, MinuteOffset);
 }
 
 void RA_PWMClass::Daylight2PWMParabola(int PreMinuteOffset, int PostMinuteOffset)


### PR DESCRIPTION
Missing a semicolon and had an extraneous int...
