### PR TITLE
Add non-blocking network support to the WiFiAlert class.

### DIFF
--- a/WiFiAlert/WiFiAlert.cpp
+++ b/WiFiAlert/WiFiAlert.cpp
@@ -55,7 +55,11 @@ void WiFiAlert::Send() {
 
 	if (AlertActive) 
 	{
-		Serial.println("Sending Alert...");
+		if (millis()%15000<500) 
+		{
+			Serial.println("Sending Alert...");
+		}
+
 		if (millis()%15000<500 && !alert)
 		{
 			Serial.println("connecting...");

--- a/WiFiAlert/WiFiAlert.cpp
+++ b/WiFiAlert/WiFiAlert.cpp
@@ -23,7 +23,7 @@ boolean WiFiAlert::IsAlert()
 void WiFiAlert::Send(char *message, boolean force)
 {
   if (force) { 
-	ResetAlert();
+	TriggerAlert();
   }
 
   if (IsAlert())

--- a/WiFiAlert/WiFiAlert.cpp
+++ b/WiFiAlert/WiFiAlert.cpp
@@ -7,6 +7,8 @@ WiFiAlert::WiFiAlert()
 {
   AlertDelay=900;
   LastAlert=0;
+  AlertActive=false;
+  AlertMsg="";
 }
 
 boolean WiFiAlert::IsAlert()
@@ -20,21 +22,78 @@ boolean WiFiAlert::IsAlert()
 
 void WiFiAlert::Send(char *message, boolean force)
 {
-  if (IsAlert() || force)
+  if (force) { 
+	ResetAlert();
+  }
+
+  if (IsAlert())
   {
     LastAlert=now();
+    AlertActive=true;
     WiFiSendAlert(message);
   }
+
+  Send();
 }
 
 void WiFiAlert::WiFiSendAlert(char *message)
 {
+  AlertMsg=message;
   Serial.print("GET /status/wifialert.aspx?id=");
   Serial.print(ReefAngel.Network.portalusername);
   Serial.print("&key=");
   Serial.print(ReefAngel.Network.portalkey);
   Serial.print("&msg=");
-  Serial.println(message);
+  Serial.println(AlertMsg);
   Serial.println("\n\n");
 }
+
+void WiFiAlert::Send() {
+#ifdef ETH_WIZ5100
+	static boolean alert = false;
+	static boolean alertConnection = false;
+
+	if (AlertActive) 
+	{
+		Serial.println("Sending Alert...");
+		if (millis()%15000<500 && !alert)
+		{
+			Serial.println("connecting...");
+			AlertClient.noblockconnect(PortalServer, 80);
+			alert=true;
+		}
+
+		if (AlertClient.checkconnect()==0x17 && !alertConnection)
+		{
+			Serial.println("connected");
+			AlertClient.print("GET /status/wifialert.aspx?id=");
+			AlertClient.print(ReefAngel.Network.portalusername);
+			AlertClient.print("&key=");
+			AlertClient.print(ReefAngel.Network.portalkey);
+			AlertClient.print("&msg=");
+			AlertClient.println(AlertMsg);
+			AlertClient.println("\n\n");
+			alertConnection=true;
+		}
+				
+		while (AlertClient.available()) {
+			char c = AlertClient.read();
+			Serial.print(c);
+			wdt_reset();
+		}
+
+		if (!AlertClient.connected() && alert) {
+			Serial.println();
+			Serial.println("disconnecting.");
+			AlertClient.stop();
+			alert=false;
+			alertConnection=false;
+			AlertActive=false;
+		}
+	}
+#else
+	AlertActive=false;
+#endif // ETH_WIZ5100
+}
+
 #endif  // wifi || ETH_WIZ5100

--- a/WiFiAlert/WiFiAlert.cpp
+++ b/WiFiAlert/WiFiAlert.cpp
@@ -55,16 +55,16 @@ void WiFiAlert::Send() {
 
 	if (AlertActive) 
 	{
-		if (millis()%15000<500) 
+		if (millis()%15000<500)
 		{
 			Serial.println("Sending Alert...");
-		}
 
-		if (millis()%15000<500 && !alert)
-		{
-			Serial.println("connecting...");
-			AlertClient.noblockconnect(PortalServer, 80);
-			alert=true;
+			if (!alert) 
+			{
+				Serial.println("connecting...");
+				AlertClient.noblockconnect(PortalServer, 80);
+				alert=true;
+			}
 		}
 
 		if (AlertClient.checkconnect()==0x17 && !alertConnection)

--- a/WiFiAlert/WiFiAlert.h
+++ b/WiFiAlert/WiFiAlert.h
@@ -12,13 +12,22 @@ class WiFiAlert
 {
 public:
   WiFiAlert();
+  void Send();
   void Send(char *message, boolean force);
   inline void Send(char *message) { Send(message,false); }
+
   inline void SetDelay(int delay) { AlertDelay=delay; }
+  inline int GetDelay() { return AlertDelay; }
+  inline void ResetAlert() { LastAlert=now()+AlertDelay; }
+  inline time_t GetLastAlert() { return LastAlert; }
+  boolean IsAlert();
 private:
   int AlertDelay;
+  int AlertActive;
+  char *AlertMsg;
   time_t LastAlert;
-  boolean IsAlert();
+  EthernetClient AlertClient;
+
   void WiFiSendAlert(char *message);
 };
 

--- a/WiFiAlert/WiFiAlert.h
+++ b/WiFiAlert/WiFiAlert.h
@@ -18,8 +18,10 @@ public:
 
   inline void SetDelay(int delay) { AlertDelay=delay; }
   inline int GetDelay() { return AlertDelay; }
-  inline void ResetAlert() { LastAlert=now()+AlertDelay; }
+  inline void ResetAlert() { LastAlert=now(); }
+  inline void TriggerAlert() { LastAlert=now()+AlertDelay; }
   inline time_t GetLastAlert() { return LastAlert; }
+  inline boolean IsActive() { return AlertActive; }
   boolean IsAlert();
 private:
   int AlertDelay;


### PR DESCRIPTION
A WiFiAlert.Send(); call will now need to be made for stateless alerts to ensure the alert is sent.

It will continue to function as previous behavior if using the WiFi attachment.