### PR TITLE
Added PROGMEM support to Send() function

### DIFF
--- a/WiFiAlert/WiFiAlert.cpp
+++ b/WiFiAlert/WiFiAlert.cpp
@@ -20,6 +20,23 @@ boolean WiFiAlert::IsAlert()
   return false;
 }
 
+void WiFiAlert::Send(const __FlashStringHelper* message) 
+{
+	Send(message,false);	
+}
+
+void WiFiAlert::Send(const __FlashStringHelper* message, boolean force) 
+{
+	Send(getString(message),force);
+}
+
+char* WiFiAlert::getString(const __FlashStringHelper* str)
+{
+	char stringBuffer[50];
+	strcpy_P(stringBuffer, (char*)str);
+	return stringBuffer;
+}
+
 void WiFiAlert::Send(char *message, boolean force)
 {
   static boolean connected = false;
@@ -85,3 +102,4 @@ void WiFiAlert::Send(char *message, boolean force)
 }
 
 #endif  // wifi || ETH_WIZ5100
+

--- a/WiFiAlert/WiFiAlert.h
+++ b/WiFiAlert/WiFiAlert.h
@@ -14,7 +14,9 @@ public:
   WiFiAlert();
   inline void Send() { Send(AlertMsg); };
   inline void Send(char *message) { Send(message,false); }
+  inline void Send(const __FlashStringHelper* message) { Send((char *)message,false); }
   void Send(char *message, boolean force);
+  inline void Send(const __FlashStringHelper* message, boolean force) { Send ((char *)message,force); };
 
   inline void SetDelay(int delay) { AlertDelay=delay; }
   inline int GetDelay() { return AlertDelay; }

--- a/WiFiAlert/WiFiAlert.h
+++ b/WiFiAlert/WiFiAlert.h
@@ -14,9 +14,11 @@ public:
   WiFiAlert();
   inline void Send() { Send(AlertMsg); };
   inline void Send(char *message) { Send(message,false); }
-  inline void Send(const __FlashStringHelper* message) { Send((char *)message,false); }
   void Send(char *message, boolean force);
-  inline void Send(const __FlashStringHelper* message, boolean force) { Send ((char *)message,force); };
+
+  void Send(const __FlashStringHelper* message);
+  void Send(const __FlashStringHelper* message, boolean force);
+  char* getString(const __FlashStringHelper* str);
 
   inline void SetDelay(int delay) { AlertDelay=delay; }
   inline int GetDelay() { return AlertDelay; }


### PR DESCRIPTION
In order to reduce memory usage, I converted the strings being passed to WiFiAlert to use flash memory instead of SRAM. I added support for the type to the class to avoid having to cast it every time to char*