### PR TITLE
Fix for Radion override and better support for DCPump Custom mode

### DIFF
--- a/RF/RF.cpp
+++ b/RF/RF.cpp
@@ -34,7 +34,7 @@ RFClass::RFClass()
 	{
 		RadionChannels[a]=0;
 		RadionChannelsOverride[a]=255;
-	}	
+	}
 }
 
 void RFClass::SendData(byte mode, byte speed, byte duration)
@@ -92,7 +92,7 @@ byte RFClass::GetChannel(byte Channel)
 	if (RadionChannelsOverride[Channel]<=100)
 		return RadionChannelsOverride[Channel];
 	else
-		return RadionChannels[Channel];	
+		return RadionChannels[Channel];
 }
 
 void RFClass::RadionWrite()
@@ -101,7 +101,7 @@ void RFClass::RadionWrite()
 	{
 		lastWrite=millis();
 		for (byte a=0;a<RF_CHANNELS;a++)
-			SendData(Radion, RadionChannels[a]*2, a);
+			SendData(Radion, GetChannel(a)*2, a);
 		SendData(Radion,0,Radion_Ready);
 	}
 }
@@ -283,4 +283,3 @@ void RFClass::ChannelRadionParabola(byte Channel, byte Start, byte End, byte Dur
 		RadionChannels[Channel]
 	));
 }
-


### PR DESCRIPTION
Fixes #210. Seems that the RadionWrite() needed to be calling GetChannel() instead of access the array directly, so it could pull in overridden channels.

Also added better support for DCPump Custom mode, which allows the user to set the Custom mode sync and anti-sync speeds via the SetMode() call. This will then utilize the feeding and water change speeds of the DCPump class. And it has the added benefit of playing nicer with the UApp, which didn't really like the Custom mode if you didn't call SetMode() with Custom.