### PR TITLE
Added RadionSlope() and RadionParabola() helper methods

### DIFF
--- a/RF/RF.cpp
+++ b/RF/RF.cpp
@@ -28,12 +28,12 @@ RFClass::RFClass()
 	UseMemory=true;
 	VortechEnable=true;
 	lastcrc=-1;
-    FeedingSpeed=255;
-    WaterChangeSpeed=255;
+    FeedingSpeed=UCHAR_MAX;
+    WaterChangeSpeed=UCHAR_MAX;
 	for ( byte a = 0; a < RF_CHANNELS; a++ )
 	{
 		RadionChannels[a]=0;
-		RadionChannelsOverride[a]=255;
+		RadionChannelsOverride[a]=UCHAR_MAX;
 	}
 }
 

--- a/RF/RF.cpp
+++ b/RF/RF.cpp
@@ -106,6 +106,16 @@ void RFClass::RadionWrite()
 	}
 }
 
+void RFClass::RadionSlope()
+{
+	ChannelWhiteSlope();
+	ChannelRoyalBlueSlope();
+	ChannelRedSlope();
+	ChannelGreenSlope();
+	ChannelBlueSlope();
+	ChannelIntensitySlope();
+}
+
 void RFClass::ChannelWhiteSlope()
 {
 	ChannelRadionSlope(Radion_White,InternalMemory.RadionSlopeStartW_read(),InternalMemory.RadionSlopeEndW_read(),InternalMemory.RadionSlopeDurationW_read());
@@ -134,6 +144,16 @@ void RFClass::ChannelBlueSlope()
 void RFClass::ChannelIntensitySlope()
 {
 	ChannelRadionSlope(Radion_Intensity,InternalMemory.RadionSlopeStartI_read(),InternalMemory.RadionSlopeEndI_read(),InternalMemory.RadionSlopeDurationI_read());
+}
+
+void RFClass::RadionSlope(byte MinuteOffset)
+{
+	ChannelWhiteSlope(MinuteOffset);
+	ChannelRoyalBlueSlope(MinuteOffset);
+	ChannelRedSlope(MinuteOffset);
+	ChannelGreenSlope(MinuteOffset);
+	ChannelBlueSlope(MinuteOffset);
+	ChannelIntensitySlope(MinuteOffset);
 }
 
 void RFClass::ChannelWhiteSlope(byte MinuteOffset)
@@ -196,6 +216,16 @@ void RFClass::ChannelRadionSlope(byte Channel, byte Start, byte End, byte Durati
 	));
 }
 
+void RFClass::RadionParabola()
+{
+	ChannelWhiteParabola();
+	ChannelRoyalBlueParabola();
+	ChannelRedParabola();
+	ChannelGreenParabola();
+	ChannelBlueParabola();
+	ChannelIntensityParabola();
+}
+
 void RFClass::ChannelWhiteParabola()
 {
 	ChannelRadionParabola(Radion_White,InternalMemory.RadionSlopeStartW_read(),InternalMemory.RadionSlopeEndW_read(),InternalMemory.RadionSlopeDurationW_read());
@@ -224,6 +254,16 @@ void RFClass::ChannelBlueParabola()
 void RFClass::ChannelIntensityParabola()
 {
 	ChannelRadionParabola(Radion_Intensity,InternalMemory.RadionSlopeStartI_read(),InternalMemory.RadionSlopeEndI_read(),InternalMemory.RadionSlopeDurationI_read());
+}
+
+void RFClass::RadionParabola(byte MinuteOffset)
+{
+	ChannelWhiteParabola(MinuteOffset);
+	ChannelRoyalBlueParabola(MinuteOffset);
+	ChannelRedParabola(MinuteOffset);
+	ChannelGreenParabola(MinuteOffset);
+	ChannelBlueParabola(MinuteOffset);
+	ChannelIntensityParabola(MinuteOffset);
 }
 
 void RFClass::ChannelWhiteParabola(byte MinuteOffset)

--- a/RF/RF.h
+++ b/RF/RF.h
@@ -46,38 +46,42 @@ public:
 	byte GetChannel(byte Channel);
 	byte inline GetOverrideChannel(byte Channel) { return RadionChannelsOverride[Channel]; };
 	void RadionWrite();
-	void ChannelWhiteSlope();	
-	void ChannelRoyalBlueSlope();		
-	void ChannelRedSlope();	
-	void ChannelGreenSlope();	
-	void ChannelBlueSlope();	
-	void ChannelIntensitySlope();	
-	void ChannelWhiteSlope(byte MinuteOffset);	
-	void ChannelRoyalBlueSlope(byte MinuteOffset);		
-	void ChannelRedSlope(byte MinuteOffset);	
-	void ChannelGreenSlope(byte MinuteOffset);	
-	void ChannelBlueSlope(byte MinuteOffset);	
+	void RadionSlope();
+	void ChannelWhiteSlope();
+	void ChannelRoyalBlueSlope();
+	void ChannelRedSlope();
+	void ChannelGreenSlope();
+	void ChannelBlueSlope();
+	void ChannelIntensitySlope();
+	void RadionSlope(byte MinuteOffset);
+	void ChannelWhiteSlope(byte MinuteOffset);
+	void ChannelRoyalBlueSlope(byte MinuteOffset);
+	void ChannelRedSlope(byte MinuteOffset);
+	void ChannelGreenSlope(byte MinuteOffset);
+	void ChannelBlueSlope(byte MinuteOffset);
 	void ChannelIntensitySlope(byte MinuteOffset);
 	void ChannelRadionSlope(byte Channel, byte Start, byte End, byte Duration);
 	void ChannelRadionSlope(byte Channel, byte Start, byte End, byte Duration, byte MinuteOffset);
-	void ChannelWhiteParabola();	
-	void ChannelRoyalBlueParabola();		
-	void ChannelRedParabola();	
-	void ChannelGreenParabola();	
-	void ChannelBlueParabola();	
-	void ChannelIntensityParabola();	
-	void ChannelWhiteParabola(byte MinuteOffset);	
-	void ChannelRoyalBlueParabola(byte MinuteOffset);		
-	void ChannelRedParabola(byte MinuteOffset);	
-	void ChannelGreenParabola(byte MinuteOffset);	
-	void ChannelBlueParabola(byte MinuteOffset);	
+	void RadionParabola();
+	void ChannelWhiteParabola();
+	void ChannelRoyalBlueParabola();
+	void ChannelRedParabola();
+	void ChannelGreenParabola();
+	void ChannelBlueParabola();
+	void ChannelIntensityParabola();
+	void RadionParabola(byte MinuteOffset);
+	void ChannelWhiteParabola(byte MinuteOffset);
+	void ChannelRoyalBlueParabola(byte MinuteOffset);
+	void ChannelRedParabola(byte MinuteOffset);
+	void ChannelGreenParabola(byte MinuteOffset);
+	void ChannelBlueParabola(byte MinuteOffset);
 	void ChannelIntensityParabola(byte MinuteOffset);
 	void ChannelRadionParabola(byte Channel, byte Start, byte End, byte Duration);
 	void ChannelRadionParabola(byte Channel, byte Start, byte End, byte Duration, byte MinuteOffset);
 	inline void VortechOff() {SetMode(TurnOff,0,0);}
 	inline void VortechOn() {SetMode(TurnOn,0,0);}
 	void inline Override(byte Channel, byte Value) { SetChannelOverride(Channel,Value); };
-	
+
 private:
 	unsigned long lastWrite;
 	byte lastcrc;

--- a/RF/RF.h
+++ b/RF/RF.h
@@ -22,6 +22,7 @@
 #ifndef __RF_H__
 #define __RF_H__
 
+#include <limits.h>
 #include <Globals.h>
 #include <InternalEEPROM.h>
 
@@ -42,7 +43,7 @@ public:
 	void SendData(byte mode, byte speed, byte duration);
 	byte RFCheck();
 	void inline SetChannel(byte Channel, byte Value) { if (Channel<RF_CHANNELS) RadionChannels[Channel]=Value; };
-	void inline SetChannelOverride(byte Channel, byte Value) { if (Value>100) Value=255; if (Channel<RF_CHANNELS) RadionChannelsOverride[Channel]=Value; };
+	void inline SetChannelOverride(byte Channel, byte Value) { if (Value>100) Value=UCHAR_MAX; if (Channel<RF_CHANNELS) RadionChannelsOverride[Channel]=Value; };
 	byte GetChannel(byte Channel);
 	byte inline GetOverrideChannel(byte Channel) { return RadionChannelsOverride[Channel]; };
 	void RadionWrite();


### PR DESCRIPTION
These methods allow the user to make a single call to recalc Radion values rather than six different calls.

Also moved to using UCHAR_MAX from limits.h instead of 255 explicitly. Overall, it's a more portable, cleaner decision, IMO. Feel free to disagree / discuss.