### PR TITLE
Small change to fix build under platformio

### DIFF
--- a/RA_Wifi/RA_Wifi.cpp
+++ b/RA_Wifi/RA_Wifi.cpp
@@ -23,7 +23,6 @@
 
 #if defined wifi || defined ETH_WIZ5100
 #include "RA_Wifi.h"
-#include <DS1307RTC.h>
 #include <ReefAngel.h>
 
 RA_Wifi::RA_Wifi()

--- a/RA_Wifi/RA_Wifi.h
+++ b/RA_Wifi/RA_Wifi.h
@@ -23,6 +23,7 @@
 #define __RA_WIFI_H__
 
 #include <Globals.h>
+#include <DS1307RTC.h>
 
 #if defined wifi || defined ETH_WIZ5100
 #include <avr/pgmspace.h>


### PR DESCRIPTION
Fix to get project to compile under platformio without throwing error about Wire.h.  This shouldn't impact anything else as far as I can tell.